### PR TITLE
Add support for non-default profiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,13 @@ class fetchDynamoDBStreamsPlugin {
 						serverless.cli.log(
 							`Fetching Streams of [ Table : ${tableName} ] in region ${region}`
 						);
+						const profile = (options && options['aws-profile']) ||
+							(serverless.service && serverless.service.provider && serverless.service.provider.profile) ||
+							process.env.AWS_PROFILE;
 						const data = await getDynamoDBStreams(
 							region,
-							tableName
+							tableName,
+							buildCredentials(profile)
 						);
 
 						myStreamArn = extractStreamARNFromStreamData(data, tableName);
@@ -71,9 +75,12 @@ const extractStreamARNFromStreamData = (data, tableName) => {
 	return streamArn;
 };
 
-const getDynamoDBStreams = async (region, tableName) => {
+const buildCredentials = (profile) => profile ? new AWS.SharedIniFileCredentials({ profile }) : undefined;
+
+const getDynamoDBStreams = async (region, tableName, credentials) => {
 	const dynamoStreams = new AWS.DynamoDBStreams({
-		region: region,
+		region,
+		credentials,
 	});
 	const params = {
 		TableName: tableName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dynamodb-stream-arn-plugin",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Fetches and then adds existing DynamoDB Table streams to serverless.yml file using table name for serverless framework",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Add support for non-default profiles. This allows for the plugin to be used when the user is managing multiple aws accounts from the same machine (E.g. one AWS account for a dev environment, another AWS account for a prod environment).

The plugin will now:
- Grab the desired AWS profile from every place Serverless or the user might set it (`serverless --aws-profile` flag, `provider.profile`, `AWS_PROFILE` env var)
- If a profile is found, builds the credentials with `AWS.SharedIniFileCredentials`
- Pass those credentials into the new `AWS.DynamoDBStreams()`

